### PR TITLE
Implement NATS message handling

### DIFF
--- a/src/bin/nats_service.rs
+++ b/src/bin/nats_service.rs
@@ -1,76 +1,203 @@
 use async_nats::connect;
-
-use hyperliquid_rust_sdk::messages::OrderRequest;
-use log::{error, info, LevelFilter};
+use ethers::signers::LocalWallet;
 use futures_util::stream::StreamExt;
+use hyperliquid_rust_sdk::messages::{ExchangeMessage, Message};
+use hyperliquid_rust_sdk::{
+    messages::{
+        ApproveAgentRequest, ApproveBuilderFeeRequest, CancelOrderRequest, ClassTransferRequest,
+        MessageHeader, MessageType, OrderRequest, SetReferrerRequest, TransferRequest,
+        UpdateIsolatedMarginRequest, UpdateLeverageRequest, VaultTransferRequest, WithdrawRequest,
+    },
+    BaseUrl, ClientCancelRequest, ClientCancelRequestCloid, ClientLimit, ClientOrder,
+    ClientOrderRequest, ExchangeClient, MarketOrderParams,
+};
+use log::{error, info, LevelFilter};
 use std::env;
-
+use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize logger
     env_logger::Builder::new()
         .filter_level(LevelFilter::Info)
         .init();
 
-    // Get NATS URL from environment or use default
     let nats_url = env::var("NATS_URL").unwrap_or_else(|_| "nats://localhost:4222".to_string());
     let subject = env::var("NATS_SUBJECT").unwrap_or_else(|_| "hyperliquid.orders".to_string());
-    
-    // Get HyperLiquid API URL from environment or use default
-    let api_url = env::var("HYPERLIQUID_API_URL")
-        .unwrap_or_else(|_| "https://api.hyperliquid.xyz".to_string());
+
+    let priv_key = env::var("PRIVATE_KEY").unwrap_or_else(|_| {
+        "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e".to_string()
+    });
+    let wallet: LocalWallet = priv_key.parse()?;
+
+    let base = match env::var("BASE_URL")
+        .unwrap_or_else(|_| "mainnet".to_string())
+        .to_lowercase()
+        .as_str()
+    {
+        "testnet" => BaseUrl::Testnet,
+        "localhost" => BaseUrl::Localhost,
+        _ => BaseUrl::Mainnet,
+    };
+
+    let client = ExchangeClient::new(None, wallet, Some(base), None, None).await?;
 
     info!("Connecting to NATS server at {}", nats_url);
     let nc = connect(&nats_url).await?;
     info!("Connected to NATS server");
 
-    info!("Subscribing to subject: {}", subject);
     let mut sub = nc.subscribe(subject.clone()).await?;
     info!("Subscribed to {}", subject);
-
     info!("NATS service started. Waiting for messages...");
 
-    // Process incoming messages
     while let Some(msg) = sub.next().await {
-        match process_message(&msg, &api_url).await {
-            Ok(_) => info!("Successfully processed message: {:?}", msg),
-            Err(e) => error!("Error processing message: {}", e),
+        if let Err(e) = process_message(&msg, &client).await {
+            error!("Error processing message: {}", e);
         }
     }
-
     Ok(())
 }
 
 async fn process_message(
     msg: &async_nats::Message,
-    api_url: &str,
+    client: &ExchangeClient,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Extract and log message headers if present
-    let headers = msg.headers.as_ref();
-    let message_type = headers
-        .and_then(|h| h.get("message_type").cloned())
-        .map(|hv| hv.to_string())
-        .unwrap_or_else(|| "order".to_string());
-    
-    let correlation_id = headers
-        .and_then(|h| h.get("correlation_id").cloned());
+    let data = &msg.payload;
+    if data.len() < 4 {
+        return Err("message too short".into());
+    }
+    let header_len = u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize;
+    let header: MessageHeader = rmp_serde::from_slice(&data[4..4 + header_len])?;
 
-    info!("Received message with type: {}, correlation_id: {:?}", 
-          message_type, correlation_id);
+    match header.msg_type {
+        MessageType::Order => {
+            let req = <OrderRequest as ExchangeMessage>::from_msgpack(data)?;
+            handle_order(req, client).await?
+        }
+        MessageType::CancelOrder => {
+            let req = <CancelOrderRequest as ExchangeMessage>::from_msgpack(data)?;
+            handle_cancel(req, client).await?
+        }
+        MessageType::ModifyOrder => {
+            log::warn!("modify order message handling not implemented");
+        }
+        MessageType::UpdateLeverage => {
+            let req = <UpdateLeverageRequest as ExchangeMessage>::from_msgpack(data)?;
+            client
+                .update_leverage(req.leverage, &req.asset, req.is_cross, None)
+                .await?;
+        }
+        MessageType::Transfer => {
+            let req = <TransferRequest as ExchangeMessage>::from_msgpack(data)?;
+            if req.asset.to_uppercase() == "USDC" {
+                client
+                    .usdc_transfer(&req.amount, &req.destination, None)
+                    .await?;
+            } else {
+                // treat as spot transfer with token in asset field
+                client
+                    .spot_transfer(&req.amount, &req.destination, &req.asset, None)
+                    .await?;
+            }
+        }
+        MessageType::Withdraw => {
+            let req = <WithdrawRequest as ExchangeMessage>::from_msgpack(data)?;
+            client
+                .withdraw_from_bridge(&req.amount, &req.destination, None)
+                .await?;
+        }
+        MessageType::ClassTransfer => {
+            // Try class transfer first
+            if let Ok(req) = <ClassTransferRequest as ExchangeMessage>::from_msgpack(data) {
+                client.class_transfer(req.amount, req.to_perp, None).await?;
+            } else if let Ok(req) = <VaultTransferRequest as ExchangeMessage>::from_msgpack(data) {
+                let addr = req.vault_address.as_deref().and_then(|a| a.parse().ok());
+                client
+                    .vault_transfer(req.is_deposit, req.usd, addr, None)
+                    .await?;
+            } else {
+                log::warn!("Unknown class transfer message");
+            }
+        }
+        MessageType::UpdateIsolatedMargin => {
+            let req = <UpdateIsolatedMarginRequest as ExchangeMessage>::from_msgpack(data)?;
+            client
+                .update_isolated_margin(req.amount, &req.asset, None)
+                .await?;
+        }
+        MessageType::ApproveAgent => {
+            let _req = <ApproveAgentRequest as ExchangeMessage>::from_msgpack(data)?;
+            let (_key, _res) = client.approve_agent(None).await?;
+            info!("Approved agent: {}", _key);
+        }
+        MessageType::SetReferrer => {
+            let req = <SetReferrerRequest as ExchangeMessage>::from_msgpack(data)?;
+            client.set_referrer(req.code, None).await?;
+        }
+        MessageType::ApproveBuilderFee => {
+            let req = <ApproveBuilderFeeRequest as ExchangeMessage>::from_msgpack(data)?;
+            client
+                .approve_builder_fee(req.builder, req.max_fee_rate, None)
+                .await?;
+        }
+    }
+    Ok(())
+}
 
-    let payload = String::from_utf8(msg.payload.to_vec())?;
-    info!("Message payload: {}", payload);
+async fn handle_order(
+    req: OrderRequest,
+    client: &ExchangeClient,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sz = req.size.parse::<f64>()?;
+    let cloid = match &req.cloid {
+        Some(c) => Some(Uuid::parse_str(c)?),
+        None => None,
+    };
 
-    let order_req: OrderRequest = serde_json::from_str(&payload)?;
-    info!("Processing order request: {:?}", order_req);
-
-    if let Some(limit_px) = &order_req.limit_price {
-        info!("Processing limit order: {:?} at {}", order_req, limit_px);
-        // TODO: client.limit_order(...).await?;
+    if let Some(px) = req.limit_price {
+        let px = px.parse::<f64>()?;
+        let order = ClientOrderRequest {
+            asset: req.asset,
+            is_buy: req.is_buy,
+            reduce_only: req.reduce_only,
+            limit_px: px,
+            sz,
+            cloid,
+            order_type: ClientOrder::Limit(ClientLimit {
+                tif: req.time_in_force,
+            }),
+        };
+        client.order(order, None).await?;
     } else {
-        info!("Processing market order: {:?}", order_req);
-        // TODO: client.market_order(...).await?;
+        let params = MarketOrderParams {
+            asset: &req.asset,
+            is_buy: req.is_buy,
+            sz,
+            px: None,
+            slippage: None,
+            cloid,
+            wallet: None,
+        };
+        client.market_open(params).await?;
+    }
+    Ok(())
+}
+
+async fn handle_cancel(
+    req: CancelOrderRequest,
+    client: &ExchangeClient,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(oid) = req.order_id {
+        let cancel = ClientCancelRequest {
+            asset: req.asset,
+            oid,
+        };
+        client.cancel(cancel, None).await?;
+    } else if let Some(cloid) = req.cloid {
+        let cancel = ClientCancelRequestCloid {
+            asset: req.asset,
+            cloid: Uuid::parse_str(&cloid)?,
+        };
+        client.cancel_by_cloid(cancel, None).await?;
     }
     Ok(())
 }

--- a/src/messages/account.rs
+++ b/src/messages/account.rs
@@ -11,7 +11,7 @@ use super::MessageType;
 pub struct UpdateIsolatedMarginRequest {
     /// The asset to update margin for
     pub asset: String,
-    
+
     /// The amount to add (positive) or remove (negative)
     pub amount: f64,
 }
@@ -30,10 +30,9 @@ impl ExchangeMessage for UpdateIsolatedMarginRequest {
     fn message_type_str(&self) -> &'static str {
         "update_isolated_margin"
     }
-    
+
     fn message_type() -> MessageType {
-        // This will be overridden by the impl_message! macro
-        unreachable!()
+        MessageType::UpdateIsolatedMargin
     }
 }
 
@@ -42,7 +41,7 @@ impl ExchangeMessage for UpdateIsolatedMarginRequest {
 pub struct ApproveAgentRequest {
     /// The agent address to approve
     pub agent_address: String,
-    
+
     /// Optional agent name
     pub agent_name: Option<String>,
 }
@@ -55,7 +54,7 @@ impl ApproveAgentRequest {
             agent_name: None,
         }
     }
-    
+
     /// Set the agent name
     pub fn with_agent_name(mut self, name: &str) -> Self {
         self.agent_name = Some(name.to_string());
@@ -67,10 +66,9 @@ impl ExchangeMessage for ApproveAgentRequest {
     fn message_type_str(&self) -> &'static str {
         "approve_agent"
     }
-    
+
     fn message_type() -> MessageType {
-        // This will be overridden by the impl_message! macro
-        unreachable!()
+        MessageType::ApproveAgent
     }
 }
 
@@ -94,10 +92,9 @@ impl ExchangeMessage for SetReferrerRequest {
     fn message_type_str(&self) -> &'static str {
         "set_referrer"
     }
-    
+
     fn message_type() -> MessageType {
-        // This will be overridden by the impl_message! macro
-        unreachable!()
+        MessageType::SetReferrer
     }
 }
 
@@ -106,7 +103,7 @@ impl ExchangeMessage for SetReferrerRequest {
 pub struct ApproveBuilderFeeRequest {
     /// The builder address
     pub builder: String,
-    
+
     /// The maximum fee rate (as a string to handle decimal precision)
     pub max_fee_rate: String,
 }
@@ -125,9 +122,8 @@ impl ExchangeMessage for ApproveBuilderFeeRequest {
     fn message_type_str(&self) -> &'static str {
         "approve_builder_fee"
     }
-    
+
     fn message_type() -> MessageType {
-        // This will be overridden by the impl_message! macro
-        unreachable!()
+        MessageType::ApproveBuilderFee
     }
 }

--- a/src/messages/order.rs
+++ b/src/messages/order.rs
@@ -11,22 +11,22 @@ use super::MessageType;
 pub struct OrderRequest {
     /// The asset to trade (e.g., "BTC")
     pub asset: String,
-    
+
     /// Whether this is a buy order (true) or sell order (false)
     pub is_buy: bool,
-    
+
     /// Size of the order in the asset's base unit
     pub size: String,
-    
+
     /// Limit price (required for limit orders)
     pub limit_price: Option<String>,
-    
+
     /// Client order ID (optional)
     pub cloid: Option<String>,
-    
+
     /// Whether this is a reduce-only order
     pub reduce_only: bool,
-    
+
     /// Time in force (e.g., "Gtc", "Ioc", "Fok")
     pub time_in_force: String,
 }
@@ -44,7 +44,7 @@ impl OrderRequest {
             time_in_force: "Ioc".to_string(),
         }
     }
-    
+
     /// Create a new limit order request
     pub fn limit(asset: &str, is_buy: bool, size: &str, price: &str) -> Self {
         Self {
@@ -57,19 +57,19 @@ impl OrderRequest {
             time_in_force: "Gtc".to_string(),
         }
     }
-    
+
     /// Set a client order ID
     pub fn with_cloid(mut self, cloid: &str) -> Self {
         self.cloid = Some(cloid.to_string());
         self
     }
-    
+
     /// Set reduce-only flag
     pub fn with_reduce_only(mut self, reduce_only: bool) -> Self {
         self.reduce_only = reduce_only;
         self
     }
-    
+
     /// Set time in force
     pub fn with_time_in_force(mut self, tif: &str) -> Self {
         self.time_in_force = tif.to_string();
@@ -85,10 +85,9 @@ impl ExchangeMessage for OrderRequest {
             "market_order"
         }
     }
-    
+
     fn message_type() -> MessageType {
-        // This will be overridden by the impl_message! macro
-        unreachable!()
+        MessageType::Order
     }
 }
 
@@ -97,10 +96,10 @@ impl ExchangeMessage for OrderRequest {
 pub struct CancelOrderRequest {
     /// The asset of the order to cancel
     pub asset: String,
-    
+
     /// The order ID to cancel (either this or cloid must be provided)
     pub order_id: Option<u64>,
-    
+
     /// The client order ID to cancel (either this or order_id must be provided)
     pub cloid: Option<String>,
 }
@@ -114,7 +113,7 @@ impl CancelOrderRequest {
             cloid: None,
         }
     }
-    
+
     /// Create a new cancel request by client order ID
     pub fn by_cloid(asset: &str, cloid: &str) -> Self {
         Self {
@@ -129,10 +128,9 @@ impl ExchangeMessage for CancelOrderRequest {
     fn message_type_str(&self) -> &'static str {
         "cancel_order"
     }
-    
+
     fn message_type() -> MessageType {
-        // This will be overridden by the impl_message! macro
-        unreachable!()
+        MessageType::CancelOrder
     }
 }
 
@@ -141,13 +139,13 @@ impl ExchangeMessage for CancelOrderRequest {
 pub struct ModifyOrderRequest {
     /// The order ID to modify (either this or cloid must be provided)
     pub order_id: Option<u64>,
-    
+
     /// The client order ID to modify (either this or order_id must be provided)
     pub cloid: Option<String>,
-    
+
     /// New size for the order (optional)
     pub new_size: Option<String>,
-    
+
     /// New price for the order (optional)
     pub new_price: Option<String>,
 }
@@ -162,7 +160,7 @@ impl ModifyOrderRequest {
             new_price: None,
         }
     }
-    
+
     /// Create a new modify request by client order ID
     pub fn by_cloid(cloid: &str) -> Self {
         Self {
@@ -172,13 +170,13 @@ impl ModifyOrderRequest {
             new_price: None,
         }
     }
-    
+
     /// Set the new size
     pub(crate) fn with_size(mut self, size: &str) -> Self {
         self.new_size = Some(size.to_string());
         self
     }
-    
+
     /// Set the new price
     pub(crate) fn with_price(mut self, price: &str) -> Self {
         self.new_price = Some(price.to_string());
@@ -190,10 +188,9 @@ impl ExchangeMessage for ModifyOrderRequest {
     fn message_type_str(&self) -> &'static str {
         "modify_order"
     }
-    
+
     fn message_type() -> MessageType {
-        // This will be overridden by the impl_message! macro
-        unreachable!()
+        MessageType::ModifyOrder
     }
 }
 
@@ -202,10 +199,10 @@ impl ExchangeMessage for ModifyOrderRequest {
 pub struct UpdateLeverageRequest {
     /// The asset to update leverage for
     pub asset: String,
-    
+
     /// The new leverage value
     pub leverage: u32,
-    
+
     /// Whether to use cross margin (true) or isolated margin (false)
     pub is_cross: bool,
 }
@@ -225,9 +222,8 @@ impl ExchangeMessage for UpdateLeverageRequest {
     fn message_type_str(&self) -> &'static str {
         "update_leverage"
     }
-    
+
     fn message_type() -> MessageType {
-        // This will be overridden by the impl_message! macro
-        unreachable!()
+        MessageType::UpdateLeverage
     }
 }

--- a/src/messages/transfer.rs
+++ b/src/messages/transfer.rs
@@ -11,10 +11,10 @@ use super::MessageType;
 pub struct TransferRequest {
     /// The asset to transfer (e.g., "USDC")
     pub asset: String,
-    
+
     /// The amount to transfer
     pub amount: String,
-    
+
     /// The destination address
     pub destination: String,
 }
@@ -34,10 +34,9 @@ impl ExchangeMessage for TransferRequest {
     fn message_type_str(&self) -> &'static str {
         "transfer"
     }
-    
+
     fn message_type() -> MessageType {
-        // This will be overridden by the impl_message! macro
-        unreachable!()
+        MessageType::Transfer
     }
 }
 
@@ -46,10 +45,10 @@ impl ExchangeMessage for TransferRequest {
 pub struct WithdrawRequest {
     /// The asset to withdraw (e.g., "USDC")
     pub asset: String,
-    
+
     /// The amount to withdraw
     pub amount: String,
-    
+
     /// The destination address
     pub destination: String,
 }
@@ -69,10 +68,9 @@ impl ExchangeMessage for WithdrawRequest {
     fn message_type_str(&self) -> &'static str {
         "withdraw"
     }
-    
+
     fn message_type() -> MessageType {
-        // This will be overridden by the impl_message! macro
-        unreachable!()
+        MessageType::Withdraw
     }
 }
 
@@ -81,7 +79,7 @@ impl ExchangeMessage for WithdrawRequest {
 pub struct ClassTransferRequest {
     /// The amount to transfer (in USD)
     pub amount: f64,
-    
+
     /// Whether to transfer to perp (true) or to spot (false)
     pub to_perp: bool,
 }
@@ -89,10 +87,7 @@ pub struct ClassTransferRequest {
 impl ClassTransferRequest {
     /// Create a new class transfer request
     pub fn new(amount: f64, to_perp: bool) -> Self {
-        Self {
-            amount,
-            to_perp,
-        }
+        Self { amount, to_perp }
     }
 }
 
@@ -100,9 +95,48 @@ impl ExchangeMessage for ClassTransferRequest {
     fn message_type_str(&self) -> &'static str {
         "class_transfer"
     }
-    
+
     fn message_type() -> MessageType {
-        // This will be overridden by the impl_message! macro
-        unreachable!()
+        MessageType::ClassTransfer
+    }
+}
+/// Request to transfer funds between vault and exchange
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VaultTransferRequest {
+    /// Whether this is a deposit into the vault (true) or withdrawal (false)
+    pub is_deposit: bool,
+    /// Amount in USD (integer, no decimals)
+    pub usd: u64,
+    /// Optional vault address in hex format
+    pub vault_address: Option<String>,
+}
+
+impl ExchangeMessage for VaultTransferRequest {
+    fn message_type_str(&self) -> &'static str {
+        "vault_transfer"
+    }
+
+    fn message_type() -> MessageType {
+        MessageType::ClassTransfer
+    }
+}
+
+/// Request to transfer spot tokens
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpotTransferRequest {
+    /// Amount to transfer
+    pub amount: String,
+    /// Destination address
+    pub destination: String,
+    /// Token identifier
+    pub token: String,
+}
+
+impl ExchangeMessage for SpotTransferRequest {
+    fn message_type_str(&self) -> &'static str {
+        "spot_transfer"
+    }
+    fn message_type() -> MessageType {
+        MessageType::Transfer
     }
 }


### PR DESCRIPTION
## Summary
- implement fully-functional `nats_service` binary
- add vault and spot transfer request types
- wire message types to exchange client methods
- expose message type constants in message implementations

## Testing
- `cargo test --offline`