### PR TITLE
Add NATS handler registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ uuid = {version = "1.6.1", features = ["v4"]}
 async-nats = "0.41.0"
 futures = "0.3.28"
 serde_derive = "1.0.175"
+bytes = "1"

--- a/NATS_SERVICE.md
+++ b/NATS_SERVICE.md
@@ -90,3 +90,17 @@ You can use the `nats` CLI to test the service:
 # Publish a test message
 nats pub hyperliquid.orders '{"action":"market_order","coin":"BTC","is_buy":true,"sz":"0.01"}'
 ```
+
+## Adding New Message Types
+
+Message handlers are registered in a global `HashMap` inside
+`src/bin/nats_service.rs`. To support a new message:
+
+1. Create a new struct implementing `ExchangeMessage` in `src/messages`.
+2. Add an async handler function that deserializes the message and calls the
+   appropriate `ExchangeClient` method.
+3. Insert the handler into the `HANDLERS` map with the corresponding
+   `MessageType`.
+
+Once added, any message of that type published to the configured NATS subject
+will be routed to your handler automatically.

--- a/src/messages/types.rs
+++ b/src/messages/types.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 /// Message type identifiers
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum MessageType {
     // Order messages (0x0-0x0F)
     Order = 0x01,


### PR DESCRIPTION
## Summary
- add a global `HANDLERS` map in `nats_service` for dispatching messages
- implement per-message handler functions
- update `process_message` to use the registry
- document adding new message types

## Testing
- `cargo test --offline`